### PR TITLE
220713 안영원 programmers 신고 결과 받기 풀이

### DIFF
--- a/220713/안영원_programmers_신고 결과 받기.java
+++ b/220713/안영원_programmers_신고 결과 받기.java
@@ -1,0 +1,58 @@
+import java.util.*;
+
+class Solution {
+    static String[] id_list;
+    static int[] answer;
+    static int[] result;
+    
+    public int[] solution(String[] id_list, String[] report, int k) {
+        answer = new int[id_list.length];
+        this.id_list = id_list;
+        
+        Set<String> set = new HashSet<>();
+        
+        for (int i = 0; i < report.length; i++) {
+            if (!set.contains(report[i])) {
+                set.add(report[i]);
+                String[] temp = report[i].split(" ");
+                addSinGo(temp[1]);
+            }
+        }
+        
+        // 정지 된 사람
+        ArrayList<String> stop = new ArrayList<>();
+        for (int i = 0; i < answer.length; i++) {
+            if (answer[i] >= k) stop.add(id_list[i]);
+        }
+        
+        result = new int[id_list.length];
+        // 메일 받는 사람
+        for (String s : set) {
+            String[] temp = s.split(" ");
+            for (String stopMan : stop) {
+                if (temp[1].equals(stopMan)) {
+                    getMail(temp[0]);
+                }
+            }
+        }
+        return result;
+    }
+    
+    static void addSinGo(String someone) {
+        for (int i = 0; i < id_list.length; i++) {
+            if (id_list[i].equals(someone)) {
+                answer[i]++;
+                return;
+            }
+        }
+    }
+    
+    static void getMail(String someone) {
+        for (int i = 0; i < id_list.length; i++) {
+            if (id_list[i].equals(someone)) {
+                result[i]++;
+                return;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<풀이>

중복 확인을 위해 Set을 사용했습니다.
report 내용 자체를 Set에 추가하였고 같은 사람이 신고한다면 Set에 이미 담겨있기때문에 신고가 불가능합니다.

해당 report에서 신고자만 분리한 뒤에 Count를 통해 신고 횟수를 넘었는지 파악하였고, 신고횟수가 넘어 정지된 사람만 따로 ArrayList에 정리하였습니다.

정지된 사람을 신고한 사람은 아까 사용한 Set에서 탐색하였고,
신고한 사람에게 메일 Count를 하나씩 증가 시켜주었고 해당 결과 배열을 최종적으로 리턴하였습니다.