### PR TITLE
220824 강소현 프로그래머스 두 큐 합 같게 만들기 풀이

### DIFF
--- a/220824/강소현_programmers_두 큐 합 같게 만들기.java
+++ b/220824/강소현_programmers_두 큐 합 같게 만들기.java
@@ -1,0 +1,55 @@
+import java.util.*;
+
+class Solution {
+    
+    static long sum1 = 0, sum2 = 0;
+    
+    static Queue<Integer> q1 = new LinkedList<>();
+    static Queue<Integer> q2 = new LinkedList<>();
+    public int solution(int[] queue1, int[] queue2) {
+
+        int answer = 0, count = 0;
+        
+        for(int i = 0; i < queue1.length; i++) {
+            sum1 += queue1[i]; // queue1 합
+            sum2 += queue2[i]; // queue2 합
+            
+            q1.offer(queue1[i]); // queue1 배열 요소 queue에 담기
+            q2.offer(queue2[i]); // queue2 배열 요소 queue에 담기
+        }
+        
+        // 합이 홀수일 경우 합이 같아질 수 없음
+        if(sum1 % 2 != 0 || sum2 % 2 != 0) answer = -1;
+        
+        while(true) {
+            // 최대로 순환 가능한 길이만큼 돌렸을 때도 합이 같아지지 않으면 -1
+            if(count == queue1.length * 4) return -1;
+            
+            // queue1 합 < queue2 합
+            if(sum1 < sum2) {
+                int value = q2.poll(); // q2에 담긴 요소를 poll();
+                sum1 += value; // queue1 합에 더해줌
+                sum2 -= value; // queue2 합에 빼줌
+                q1.offer(value); // q2에서 poll() 한 요소는 q1에 담음
+                
+            }
+            // queue1 합 > queue2 합
+            else if(sum1 > sum2) { 
+                int value = q1.poll(); // q1에 담긴 요소를 poll();
+                sum1 -= value; // queue1 합에 빼줌
+                sum2 += value; // queue2 합에 더해줌
+                q2.offer(value); // q1에서 poll() 한 요소는 q2에 담음
+            } 
+            // 합이 같아지면 break
+            else {
+                break;
+            }
+            
+            count++;
+        }
+        
+        answer = count;
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
1. queue1 배열과 queue2 배열에 담긴 값 sum1, sum2 변수에 각각 합을 담는다. 이후 Queue q1, q2에 해당 배열 값을 담는다.
2. `sum1 < sum2`일 경우 q2 값을 poll() 해서 sum1에는 더해주고 sum2에는 빼준다. 이후 q1에 poll()한 값을 넣는다.
3. `sum1 > sum2`일 경우 q1 값을 poll() 해서 sum2에는 더해주고 sum1에는 빼준다. 이후 q2에 poll()한 값을 넣는다.
4. sum1, sum2를 long 타입으로 지정해야 테스트케이스 25~27에 오버플로우가 발생하지 않는다.
5. 해당 연산을 반복했을 때, 합이 같아지지 않으면 -1을 반환해야 한다. 이에 `queue1 배열 크기 * queue2 배열 크기`를 해주었더니 시간 초과가 났다. 이 부분은 내가 문제 제한사항을 간과했던 거 같다. 그래서 최대로 순환할 수 있는 횟수를 고려하여 queue1 배열 크기 * 4를 해주었다.