### PR TITLE
220829 강소현 프로그래머스 오픈채팅방 풀이

### DIFF
--- a/220829/강소현_programmers_오픈채팅방.java
+++ b/220829/강소현_programmers_오픈채팅방.java
@@ -1,0 +1,45 @@
+import java.util.*;
+
+class Solution {
+    
+    public String[] solution(String[] record) {
+        
+        HashMap<String, String> map = new HashMap<>();
+        ArrayList<String> list = new ArrayList<>();
+        
+        for(String str : record) {
+            StringTokenizer st = new StringTokenizer(str);
+
+            String input = st.nextToken();
+            String id = st.nextToken();
+            String nickname = "";
+            
+            // 채팅방에서 나간 유저는 닉네임이 주어지지 않는다.
+            // Enter, Change 상태일 경우 id랑 닉네임 담으면 된다.
+            if(!input.equals("Leave")) {
+                nickname = st.nextToken();
+                
+                map.put(id, nickname);
+            }
+        }
+        
+        for(String str : record) {
+            StringTokenizer st = new StringTokenizer(str);
+
+            String input = st.nextToken();
+            String id = st.nextToken();
+            
+            if(input.equals("Enter")) {
+                list.add(map.get(id) + "님이 들어왔습니다.");
+            }else if(input.equals("Leave")) {
+                list.add(map.get(id) + "님이 나갔습니다.");
+            }
+        }
+        
+        String[] answer = new String[list.size()];
+        for(int i = 0; i < list.size(); i++){
+            answer[i] = list.get(i);
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
- 상태, 아이디, 닉네임을 받고 상태가 `Enter` , `Change` 일 경우에 아이디와 닉네임을 map에 담는다. 이는 `채팅방에서 나간 유저가 닉네임을 변경하는 등 잘못 된 입력은 주어지지 않는다.` 라는 조건 때문이다.
- 이후 다시 상태를 확인하여 map에 담긴 닉네임 + 상태(채팅방에 들어왔는지 나갔는지)를 list에 담는다.