### PR TITLE
220907 박동준 백준 13397 구간 나누기 2 풀이

### DIFF
--- a/220907/박동준_boj_13397_구간 나누기2.py
+++ b/220907/박동준_boj_13397_구간 나누기2.py
@@ -1,0 +1,27 @@
+
+n,m=map(int,input().strip().split())
+arr=list(map(int,input().strip().split()))
+
+def gugan(mid):
+    max_x=min_x=arr[0]
+    cnt=1
+    for i in range(1,n):
+        max_x=max(max_x,arr[i])
+        min_x=min(min_x,arr[i])
+        if max_x - min_x > mid:
+            cnt +=1
+            max_x=arr[i]
+            min_x=arr[i]
+    return cnt
+
+start, end = 0, max(arr)
+result=0
+while start<=end:
+    mid=(start+end)//2
+    if gugan(mid)<=m:
+        end = mid-1
+        result=mid
+    else:
+        start = mid+1
+
+print(result)


### PR DESCRIPTION
우선 왜 이분탐색으로 값을 찾아야 하는 이유에 대해서 생각 해 보았다.

bf 로 풀 경우, M 이하의 구간이 되는 모든 경우를 찾아야 한다 --> M의 값이 1< M < 5000 이기 때문에, 딱 봐도 많은 case가 생길 거라고 확신할 수 있다. 
그렇다면 우리는 구간을 어떻게 나눌까? 가 아니라 어떤값이 최소값이 될 수 있을까? 를 기준으로 역탐색을 실시해야한다.

1번째 case에서  3이라는 숫자를 사용하면, m=3일때 구간을 초과한다. 따라서 mid 값을 +1 해주고 시작점을 mid +1한 값으로 설정한다. 다시 중간점 으로부터 탐색을 반복하면서, 구간의 갯수가 초과가 되었을때는 end 값을 mid-1로 해주면 끝

어떻게 이분 탐색을 사용하고, 기준값, 구간 변경 조건의 값을 어떻게 설정하느냐에따라 복잡한 문제도 이진탐색으로 해결할 수 있음을 배웠다.