### PR TITLE
220915 박동준 백준 1937 욕심쟁이 판다 풀이

### DIFF
--- a/220915/박동준_boj_1937_욕심쟁이판다.py
+++ b/220915/박동준_boj_1937_욕심쟁이판다.py
@@ -1,0 +1,43 @@
+import sys
+sys.setrecursionlimit(10**6)
+N = int(input())
+
+arr = [list(map(int, input().split())) for _ in range(N)]
+
+dx = [0,0,-1,1]
+dy = [-1,1,0,0]
+
+dp = [[0]*N for _ in range(N)]
+# print(dp, arr)
+
+
+# 메모이제이션을 통한 재귀탐색 가지치기
+# 방문 지점에서 갈 수 있는 최대 거리를 미리 구함
+visit = [[False]*N for _ in range(N)]
+def dfs(x,y):
+    
+    # 가지치기
+    if dp[x][y]:
+        return dp[x][y]
+    
+    for i in range(4):
+        nx = x + dx[i]
+        ny = y + dy[i]
+        if 0 <= nx < N  and 0 <= ny < N and arr[x][y] < arr[nx][ny]:
+            dp[x][y] = max(dp[x][y],dfs(nx,ny) + 1)
+
+    return dp[x][y]        
+            
+            
+
+
+for i in range(N):
+    for j in range(N):
+        dfs(i,j)
+
+count = 0
+for i in range(N):
+    for j in range(N):
+        count = max(count,dp[i][j])
+
+print(count+1)


### PR DESCRIPTION
1. 일단 dfs 인것을 인지함.
2. 그런데 모든 좌표에 대해서 dfs를 실행시키는것을 알게됨 이때, 시간 복잡도가 증가하여 시간초과가 무조건 날것이라고 생각함. 
3. 첫번째 풀이로 가는 모든 경로에 대해서 count 값을 기존의 값과 비교하고  저장하는 가지치기를 시도함, recursion error 이후 수정하였으나 시간초과가 났음.
4. 시간 초과가 난 이유는 불필요한 탐색이 존재한다는 것이였음 그래서 이걸 오또카지오또카지 하고 있다가 해결책을 생각함
5. 경로에 대한 최댓값을 갱신해주는것은 좋았으나, 내가 짠 로직으로는 방문했던 배열을 계속 탐색하는 문제가 발생함.
6. dfs의 return 값을 제공하여, 끝점부터 값을 받아오게 하는 로직과, 해당 포인트에서 갈 수 있는 최대 거리를 저장하고, 이 지점에 대한 정보가 있다면 해당 지점의 값을 return함 그러면 다른곳에서 방문했을 때 + 1을 해주기만해도 해당 구간들 다 탐색할 필요가 없음.
7. 끝!