### PR TITLE
220929 강소현 프로그래머스 전력망을 둘로 나누기 풀이

### DIFF
--- a/220929/강소현_programmers_전력망을 둘로 나누기.java
+++ b/220929/강소현_programmers_전력망을 둘로 나누기.java
@@ -1,0 +1,56 @@
+import java.util.*;
+
+class Solution {
+    
+    static int n;
+    static List<Integer>[] list;
+
+    public int solution(int n, int[][] wires) {
+        
+        this.n = n;
+       
+        list = new ArrayList[n + 1];
+
+        for(int i = 1; i <= n; i++) {
+            list[i] = new ArrayList<>();
+        }
+        
+        for(int[] wire : wires) {
+            list[wire[0]].add(wire[1]);
+            list[wire[1]].add(wire[0]);
+        }
+        
+        int answer = 100;
+        for(int[] wire : wires) {
+            answer = Math.min(answer, solve(wire[0], wire[1]));
+        }
+        return answer;
+    }
+    
+    private static int solve(int start, int end) {
+        Queue<Integer> queue = new LinkedList<>();
+        boolean[] visited = new boolean[n + 1];
+        
+        int ret = 0;
+
+        queue.add(start);
+        visited[start] = true;
+
+        while (!queue.isEmpty()) {
+            int now = queue.poll();
+            
+            ret++;
+
+            for (int next : list[now]) { 
+                // end랑 연결된 노드 끊기 또는 이미 방문했을 경우
+                if(next == end || visited[next]) continue;
+                
+                queue.offer(next);
+                visited[next] = true;
+            }
+        }
+
+        // 두 전력망이 가지고 있는 송전탑 개수의 차이
+        return Math.abs((n - ret) - ret);
+    }
+}


### PR DESCRIPTION
- 탐색 할 때, 한 쪽만 탐색했습니다. 노드 카운트 시키고 `(n - ret) - ret` 해서 구했습니다.
- 다음 노드 탐색 할 때 `end`랑 일치하고 이미 방문했으면 끊어줬습니다.
- dfs로 바꿔보려고 했는데 어제 못 푼 문제가 생각나서 bfs로만 풀고 갑니다. 총총