### PR TITLE
220929 박동준 프로그래머스 전력망 둘로 나누기 풀이

### DIFF
--- a/220929/박동준_programmers_전력망 둘로 나누기.py
+++ b/220929/박동준_programmers_전력망 둘로 나누기.py
@@ -1,0 +1,44 @@
+def solution(n, wires):
+    answer = -1
+
+    par = list(range(n+1))
+    rank = [0 for _ in range(n+1)]
+    
+
+    def find(x):
+        if par[x] ==x:
+            return x
+        else:
+            par[x] = find(par[x])
+            return par[x]
+    
+    def union(x,y):
+        x = find(x)
+        y = find(y)
+        if x != y:
+            par[x] = y
+        
+        # if rank[x] < rank[y]:
+        #     par[x] = y
+        # elif rank[x] > rank[y]:
+        #     par[y] = x
+        # else:
+        #     par[x] = y
+        #     rank[y] += 1
+    answer = 99999999999999999999
+    result = 99999999999999999999
+    for i in range(len(wires)):
+        par = list(range(n+1))
+        rank = [0 for _ in range(n+1)]
+        for a,b in (wires[:i] + wires[i+1:]):
+            if find(a) != find(b):
+                union(a,b)
+    
+        dic = {}
+        for k in range(1, n+1):
+            a  = find(k)
+            if dic.get(a) == None:
+                dic[a] = 1
+            else:
+                dic[a] += 1
+    return result


### PR DESCRIPTION
간선을 하나씩 제거하고 이것들의 집합을 구하는 문제이다.

집합을 가장 쉽게 구하는 방법은 union, find를 이용해야겠다! 라고 생각하고 코드 작성을 시작했다.

오랜만에 풀게 된 union find 문제라서 실수 한 점은
union by rank를 이용하여 나온 par (= 부모의 정보) 가 있더라도 모든 구간이 통일되지 않는다는 점인데
즉, 마지막에 각 지점의 집합을 알기 위해서는 find 함수를 한번 더 호출해야 한다는 것이다.

그 외에는 이중 for 문을 통해 하나의 간선을 제외하고 union find를 수행하면 된다.
