### PR TITLE
221027 강소현 백준 1715 카드 정렬하기 풀이

### DIFF
--- a/221027/강소현_boj_1715_카드 정렬하기.java
+++ b/221027/강소현_boj_1715_카드 정렬하기.java
@@ -1,0 +1,34 @@
+package boj;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+/* boj 1715번 카드 정렬하기 */
+public class boj_1715 {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+
+        PriorityQueue<Integer> pq = new PriorityQueue<>();
+
+        for(int i = 0; i < N; i++) {
+            pq.offer(Integer.parseInt(br.readLine()));
+        }
+
+        int sum, result = 0;
+        while(pq.size() > 1) {
+            int num1 = pq.poll();
+            int num2 = pq.poll();
+
+            sum = num1 + num2; // 큐에 담아 줄 묶음 합
+            result += sum; // 누적
+
+            pq.offer(sum);
+        }
+
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
<풀이>
- 작은 수부터 더해줘야 돼서 우선순위 큐 사용
- 두 개의 숫자를 뽑아야 하므로 while문 돌릴 때 pq.size() > 1