### PR TITLE
221031 안영원 프로그래머스 스킬트리 풀이

### DIFF
--- a/221031/안영원_programmers_스킬트리.java
+++ b/221031/안영원_programmers_스킬트리.java
@@ -1,0 +1,33 @@
+class Solution {
+    public int solution(String skill, String[] skill_trees) {
+        int answer = 0;
+        
+        for (int i = 0; i < skill_trees.length; i++) {
+            boolean isCan = true; // 현재 스킬트리가 가능한지 확인
+            int idx = 0; // 선행 스킬 번호
+            
+            for (int j = 0; j < skill_trees[i].length(); j++) {
+                if (isCan) {
+                    char cur = skill_trees[i].charAt(j); // 현재 스킬
+                    if (checkInSkill(cur, skill)) { // 선행 스킬이 필요하다면
+                        if (skill.charAt(idx) == cur) idx++; // 현재 선행 스킬 번호와 일치하면 다음 선행스킬로 넘김
+                        else isCan = false; // 선행 스킬 없이 다음 스킬이 왔다면 안됨
+                    }
+                }
+            }
+            if (isCan) answer++;
+        }
+        
+        return answer;
+    }
+    
+    // 현재 스킬이 선행스킬이 필요한 스킬인지 확인
+    static boolean checkInSkill(char cur, String skill) {
+        for (int i = 0; i < skill.length(); i++) {
+            char check = skill.charAt(i);
+            if (check == cur) return true;
+        }
+        
+        return false;
+    }
+}


### PR DESCRIPTION
주어진대로 구현하면 되는 문제

문제에서 주어진 skill_trees와 skill의 범위가 20, 26으로써 전체를 탐색해서 확인해도 시간상 문제가 없어 전체 탐색으로 코드를 구현
또한 skill_trees의 원소에 중복이 없기 때문에 구현이 더욱더 쉬웠다.

현재 유저의 스킬트리를 탐색하면서 선행스킬이 필요한 즉, skill 내부에 있는 스킬이 포함되어 있다면(checkInSkill 함수)
skill 내부의 첫번째 스킬과 유저가 찍은 스킬이 일치하는지 확인해준다. -> 선행스킬에 맞게끔 찍었는지
만약 다르다면 이전 선행스킬을 찍지않고 다음 스킬을 찍은 것이므로 X
같다면 다음 선행스킬을 탐색하게끔 idx를 증가시켜준다.

말로 설명이 쉽지않아 코드에 주석을 열심히 적었다...