### PR TITLE
221114 박동준 백준 12869 뮤탈리스크 풀이

### DIFF
--- a/221114/박동준_boj_12869_뮤탈리스크.py
+++ b/221114/박동준_boj_12869_뮤탈리스크.py
@@ -1,0 +1,33 @@
+import heapq
+
+N = int(input())
+
+q = []
+arr = list(map(int, input().split()))
+
+for i in range(N):
+    heapq.heappush(q,-arr[i])
+
+deal = [9,3,1]
+flag = False
+count = 0
+while q:
+    del_scv = []
+    # 3번만 쨀 수 있음
+    for i in range(3):
+        if q:
+            a = heapq.heappop(q)
+            del_scv.append(a)
+        else:
+            break
+    print(del_scv)
+    for i in range(len(del_scv)):
+        k = (-1*del_scv[i]) - deal[i]
+        if k <= 0:
+            continue
+        else:
+            heapq.heappush(q,-k)
+    print(q)
+    count += 1
+
+print(count)


### PR DESCRIPTION
실패함.

현재 접근법
1. heapq를 이용하여 제일 큰 수부터 9,3,1 순서로 빼게하고 count를 늘리는 방식으로 접근
2. 현재 1번 테케 빼고 맞아서 print를 통해 확인한 결과
3. 무조건 큰 순서대로 빼는것이 아님을 확인
4. 다시 접근할 필요가 있음.