### PR TITLE
221114 장예찬 백준 12869 뮤탈리스크 풀이 & 221116 장예찬 프로그래머스 연속 부분 수열 합의 개수 풀이

### DIFF
--- a/221114/장예찬_boj_12869_뮤탈리스크.py
+++ b/221114/장예찬_boj_12869_뮤탈리스크.py
@@ -1,0 +1,43 @@
+# https://www.acmicpc.net/problem/12869
+# 예상 알고리즘: 탐색, DP
+# 베스트 알고리즘: DP
+
+import sys
+from itertools import permutations
+
+input = sys.stdin.readline
+
+def solutionInput():
+    N = int(input())
+    SCVs = list(map(int, input().split()))
+    return N, SCVs
+
+deals = [9, 3, 1]
+def solution(N, SCVs):
+    SCVs = SCVs + (3 - N) * [0] #3개 이하의 SCV가 있을 때를 위해 0을 채워줌
+    comb = list(permutations([9, 3, 1]))
+    dp = [[[0]*61 for _ in range(61)] for _ in range(61)]
+    dp[SCVs[0]][SCVs[1]][SCVs[2]] = 1
+    
+    for i in range(SCVs[0], -1, -1):
+        for j in range(SCVs[1], -1, -1):
+            for k in range(SCVs[2], -1, -1):
+                if dp[i][j][k] > 0:
+                    # comb를 순회해서 i, j, k에서 빼고 0보다 작으면 0으로 초기화
+                    for c in comb:
+                        ni = max(i - c[0], 0)
+                        nj = max(j - c[1], 0)
+                        nk = max(k - c[2], 0)
+                        # 처음 도착한 경우 또는 더 적을 경우에만 dp를 업데이트
+                        if dp[ni][nj][nk] == 0 or dp[ni][nj][nk] > dp[i][j][k] + 1:
+                            dp[ni][nj][nk] = dp[i][j][k] + 1                    
+    
+    return dp[0][0][0] - 1
+
+N, SCVs = solutionInput()
+print(solution(N, SCVs))
+
+
+
+
+

--- a/221116/장예찬_programmers_연속 부분 수열 합의 개수.py
+++ b/221116/장예찬_programmers_연속 부분 수열 합의 개수.py
@@ -1,0 +1,17 @@
+# 
+# 예상 알고리즘:
+# 베스트 알고리즘:
+
+def solution(elements):
+    elementsTemp = list(elements) + list(elements) #원형 수열이므로 두 번 붙여줌
+    answerSet = set(elements)
+
+    print(elements)
+    # 길이가 1씩 늘어나는 원형 수열의 부분 수열의 합을 구함
+    for i in range(1, len(elements)+1):
+        for j in range(len(elements)):
+            answerSet.add(sum(elementsTemp[j:j+i]))
+    return len(answerSet)
+
+# 테스트
+print(solution([7, 9, 1, 1, 4])) # 18

--- a/221116/장예찬_programmers_연속 부분 수열 합의 개수.py
+++ b/221116/장예찬_programmers_연속 부분 수열 합의 개수.py
@@ -1,16 +1,19 @@
-# 
-# 예상 알고리즘:
-# 베스트 알고리즘:
+# https://school.programmers.co.kr/learn/courses/30/lessons/131701
+# 예상 알고리즘: 구현
+# 베스트 알고리즘: 구현
 
 def solution(elements):
-    elementsTemp = list(elements) + list(elements) #원형 수열이므로 두 번 붙여줌
+    elementsTemp = [[idx, d] for idx, d in enumerate(elements)] # 초기 길이가 1인 부분수열의 인덱스와 값들을 저장
     answerSet = set(elements)
 
-    print(elements)
-    # 길이가 1씩 늘어나는 원형 수열의 부분 수열의 합을 구함
-    for i in range(1, len(elements)+1):
-        for j in range(len(elements)):
-            answerSet.add(sum(elementsTemp[j:j+i]))
+    length = len(elements)
+    for _ in range(len(elements) - 1): # 부분수열의 길이가 1인 경우는 이미 구했으므로 length - 1번 반복
+        for temp in elementsTemp:
+            # 원형으로 인덱스를 1 증가시킴
+            temp[0] = (temp[0] + 1) % length
+            temp[1] += elements[temp[0]] # 값에 다음 인덱스의 값을 더함
+            answerSet.add(temp[1]) # 부분수열의 합을 저장
+
     return len(answerSet)
 
 # 테스트


### PR DESCRIPTION
### 뮤탈리스크
<풀이과정>
1. dp로 푼다.
2. 3차원 배열의 인덱스들을 SCV 1번 2번 3번의 체력이라 생각함 즉 dp란 3차원  배열 dp[i][j][k]의 i, j, k는 각 SCV의 체력을 의미함
3. dp가 가지는 값은 해당 체력이 되기 위한 최소 카운팅 값임
4. 3중 for문을 이용해서 최대 체력에서부터 빼기 시작한다.
5.방문하기 전인 경우 혹은 새로운 체력 상태가 더 적은 카운팅으로 도착 가능하면 업데이트 함
6. 순회 완료 후 dp[0][0][0]를 출력

### 1. 연속 부분 수열 합의 개수
<풀이과정> 
1. 집합 자료구조로 푼다.
2. elements를 두 개 이어서 붙인다.
3. 일정 길이의 부분 수열을 모두 구해 집합에 넣는다.
4. 길이 출력

### 2. 연속 부분 수열 합의 개수
<풀이과정>
1. 집합 자료구조로 푼다.
2. 합을 구한 인덱스를 저장하는 [idx, 합] 를 원소로 갖는 리스트를 만든다.
3. 인덱스를 1씩 증가시키면서 기존의 합에서 바로 옆 인덱스의 원소를 더하면 길이가 늘어난 합이다.
4. 이를 elements의 길이 - 1만큼 반복하면 모든 경우가 구해진다.
5. 길이 출력

시간복잡도가 개선됨!
