### PR TITLE
221116 안영원 프로그래머스 연속 부분 수열 합의 개수 풀이

### DIFF
--- a/221116/안영원_programmers_연속 부분 수열 합의 개수.java
+++ b/221116/안영원_programmers_연속 부분 수열 합의 개수.java
@@ -1,0 +1,24 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int[] elements) {
+        // 원형 배열이라 2배로 늘림
+        int[] nElements = new int[elements.length * 2];
+        for (int i = 0; i < elements.length; i++) {
+            nElements[i] = elements[i];
+        }
+        for (int i = elements.length; i < nElements.length; i++) {
+            nElements[i] = elements[i - elements.length];
+        }
+        
+        // 중복 제외를 위해 Set 사용
+        Set<Integer> set = new HashSet<>();
+        // 길이가 1인 수열부터 elements.length인 수열까지 모두 찾아서 set에 넣기
+        for (int i = 0; i < elements.length; i++) {
+            for (int j = i; j < elements.length; j++) {
+                set.add(Arrays.stream(nElements, j, j+i).sum());
+            }
+        }
+        return set.size();
+    }
+}


### PR DESCRIPTION
원형 배열이기 때문에 끝자리에서 처음으로 이어지는 경우를 위해서 원래 배열의 2배만큼 생성하고 뒤에 원래 배열을 추가로 넣어준다.

길이가 1인 수열부터 elements의 길이인 수열까지 각 자리수에서 계산하여줌.
i가 수열의 길이를 나타내고
j는 시작점을 나타냄

j에서 i길이까지의 수열을 더하는 것은 stream을 활용한 방법을 검색을 통해 확인하여 사용함

원이라서 원래 배열 2배로 이어줘야하는 점이 이해가 잘안가서 오래걸림
이해하고 나서 코드 구현은 어렵지 않았음.