### PR TITLE
221116 박동준 프로그래머스 연속 부분 수열 합의 개수 풀이

### DIFF
--- a/221116/박동준_programmers_연속 부분 수열 합의 개수.py
+++ b/221116/박동준_programmers_연속 부분 수열 합의 개수.py
@@ -1,0 +1,12 @@
+def solution(elements):
+    arr = set()
+    length = len(elements)
+    elements += elements
+    
+    for i in range(length):
+        a = 0
+        for j in range(length):
+            a += elements[i+j]
+            arr.add(a)
+    
+    return len(arr)


### PR DESCRIPTION
제일 처음 list를 이용하여 결과를 가지는 arr에 값이 있는지 없는지 판별을 하려고 했음.
이 in으로 인한 시간복잡도가 올라간다는것을 인지하고
set으로 변경함

list의 경우 끝에 같은 배열을 더해주어, 범위 초과 없이 원하는 길이만큼 탐색할 수 있게함.
2중 for문에서
첫번째 for문의 i는 몇번째 idx 에서 시작하는지
두 번째 for문의 j는 총 보아야하는 길이를 뜻함
쭉 더해주면서 값을 set에 add 하면 중복된 값은 자동으로 제거