### PR TITLE
221205 안영원 프로그래머스 명예의 전당 (1) 풀이

### DIFF
--- a/221205/ 안영원_programmers_명예의 전당 (1).java
+++ b/221205/ 안영원_programmers_명예의 전당 (1).java
@@ -1,0 +1,16 @@
+import java.util.*;
+
+class Solution {
+    public int[] solution(int k, int[] score) {
+        int[] answer = new int[score.length];
+        PriorityQueue<Integer> pq = new PriorityQueue<>();
+        
+        for (int i = 0; i < score.length; i++) {
+            pq.offer(score[i]);
+            
+            if (pq.size() > k) pq.poll();
+            answer[i] = pq.peek();
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
기존 문자열 나누기는 풀었던 문제라서 다른거 풀었습니다. [문자열 나누기 풀이보기](https://toload.tistory.com/entry/JAVA-Programmers-%EB%AC%B8%EC%9E%90%EC%97%B4-%EB%82%98%EB%88%84%EA%B8%B0)

---

오늘꺼 풀이
k명의 가수가 명예의 전당에 오를 수 있음.
k명의 가수는 점수별로 정하기 때문에 k명이 쌓일 때까지 k일동안은 누구나 명예의 전당에 오르고 그 이후부터는 점수가 낮은 사람은 명예의 전당에서 탈락함.
매일마다 명예의 전당 최하점을 찾아 해당 값을 리턴해주어야함.

간단하게 우선순위큐를 이용해서 구현
우선순위큐의 사이즈가 k보다 작으면 계속 넣어주고 크다면 넣은다음 하나를 빼줌으로써 점수가 낮은 사람을 탈락시킴.
우선순위큐의 peek을 이용해서 가장 점수가 낮은 사람을 매일 확인함.