### PR TITLE
221221 안영원 백준 9935 문자열 폭발 풀이

### DIFF
--- a/221221/안영원_boj_9935_문자열 폭발.java
+++ b/221221/안영원_boj_9935_문자열 폭발.java
@@ -1,0 +1,37 @@
+import java.io.*;
+
+public class Main {
+
+	public static void main(String[] args) throws IOException {
+		StringBuilder sb = new StringBuilder();
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		String origin = br.readLine();
+		String bombWord = br.readLine();
+		
+		for (int i = 0; i < origin.length(); i++) {
+			sb.append(origin.charAt(i));
+
+			// 폭발 문자열과 크기가 같아지는 순간부터 체크
+			if (sb.length() >= bombWord.length()) {
+				boolean isBomb = true;
+
+                // 하나씩 비교하며 폭발 문자열인지 확인
+				for (int j = 0; j < bombWord.length(); j++) {
+					if (sb.charAt(sb.length() - bombWord.length() + j) != bombWord.charAt(j)) {
+						isBomb = false;
+						break;
+					};
+				}
+
+                // 폭발 문자열이 확인되면 제거
+				if (isBomb) {
+					sb.delete(sb.length() - bombWord.length(), sb.length());
+				}
+			}
+		}
+		
+		if (sb.length() == 0) System.out.println("FRULA");
+		else System.out.println(sb);
+	}
+}

--- a/221221/안영원_boj_9935_문자열 폭발.java
+++ b/221221/안영원_boj_9935_문자열 폭발.java
@@ -16,7 +16,7 @@ public class Main {
 			if (sb.length() >= bombWord.length()) {
 				boolean isBomb = true;
 
-                // 하나씩 비교하며 폭발 문자열인지 확인
+                		// 하나씩 비교하며 폭발 문자열인지 확인
 				for (int j = 0; j < bombWord.length(); j++) {
 					if (sb.charAt(sb.length() - bombWord.length() + j) != bombWord.charAt(j)) {
 						isBomb = false;
@@ -24,7 +24,7 @@ public class Main {
 					};
 				}
 
-                // 폭발 문자열이 확인되면 제거
+                		// 폭발 문자열이 확인되면 제거
 				if (isBomb) {
 					sb.delete(sb.length() - bombWord.length(), sb.length());
 				}


### PR DESCRIPTION
문자열 폭발인데 문자 폭발로 문제를 풀이해서 다시 푸느라 시간이 좀 걸렸습니다.
웬지 2%에서 진행이 안되더라..

N의 최대가 100만이라 N^2으로 풀이하면 시간초과라서 한 번 탐색으로 풀이되는 방법을 고민하다가 StringBuilder를 이용
기존 문자열을 앞에서 부터 탐색하면서 StringBuilder에 추가해주고 StringBuilder 크기가 폭발 문자열과 같거나 크다면 이전 문자열을 확인하며 폭발 문자열인지 확인.
폭발 문자열이 맞다면 제거해주고 아니라면 쭉 진행하는 방식.

VS Code에서는 sb.isEmpty()가 먹혔는데 백준에선 안되서 length() == 0 으로 대체함.
아마 자바 8에서는 없는 것인가봄.
